### PR TITLE
Make jinja2 dependency explicit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,10 @@ build-backend = "hatchling.build"
 name = "sphinxext-altair"
 authors = [ {name = "sphinxext-altair Contributors"} ]
 dependencies = [
-    "sphinx",
-    "docutils",
     "altair>=4.0.0",
+    "docutils",
+    "jinja2",
+    "sphinx",
     "typing_extensions>=4.0.1; python_version<\"3.8\"",
 ]
 description = "sphinxext-altair: Sphinx extension for embedding Altair charts"


### PR DESCRIPTION
This adds `jinja2` as an explicit dependency as it gets imported directly, e.g., here:

https://github.com/altair-viz/sphinxext-altair/blob/7e6cb9b501a86361ca8fc0be4ac0b2d2fc08b836/sphinxext_altair/altairplot.py#L66

This fix is inconsequential, because jinja2 gets pulled into my environment through altair already (see [here](https://github.com/altair-viz/altair/blob/master/pyproject.toml#L21)).