### PR TITLE
fix: Display code that triggered an error in warning

### DIFF
--- a/sphinxext_altair/altairplot.py
+++ b/sphinxext_altair/altairplot.py
@@ -306,11 +306,14 @@ def html_visit_altair_plot(self: altair_plot, node: nodes.Element) -> None:  # n
             )
             self.body.append(html)
         else:
+            err_file = node["rst_source"]
+            line_no = node["rst_lineno"]
             msg = (
-                f"altair-plot: {node['rst_source']}:{node['rst_lineno']} Malformed block. "
-                "Last line of code block should define a valid altair Chart object."
+                f"Malformed block.\n"
+                f"  {err_file}:{line_no}\n"
+                f"    Last line of code block should define a valid altair Chart object."
             )
-            warnings.warn(msg, stacklevel=1)
+            warnings.warn(msg, AltairPlotWarning, stacklevel=1)
         raise nodes.SkipNode
 
 

--- a/sphinxext_altair/altairplot.py
+++ b/sphinxext_altair/altairplot.py
@@ -233,6 +233,9 @@ class AltairPlotDirective(Directive):
         return result
 
 
+class AltairPlotWarning(UserWarning): ...
+
+
 def html_visit_altair_plot(self: altair_plot, node: nodes.Element) -> None:  # noqa: C901
     # Execute the code, saving output and namespace
     namespace = node["namespace"]
@@ -242,14 +245,19 @@ def html_visit_altair_plot(self: altair_plot, node: nodes.Element) -> None:  # n
             chart = eval_block(node["code"], namespace)
         stdout = f.getvalue()
     except Exception as err:
+        err_file = node["rst_source"]
+        line_no = node["rst_lineno"]
+        err_code = node["code"]
         msg = (
-            f"altair-plot: {node['rst_source']}:{node['rst_lineno']} "
-            f"Code Execution failed: {type(err).__name__}: {err!s}"
+            f"Code Execution failed.\n"
+            f"  {err_file}:{line_no}\n"
+            f"    {type(err).__name__}: {err!s}\n"
+            f"    {err_code}"
         )
         if node["strict"]:
             raise ValueError(msg) from err
         else:
-            warnings.warn(msg, stacklevel=1)
+            warnings.warn(msg, AltairPlotWarning, stacklevel=1)
             raise nodes.SkipNode from err
 
     if chart_name := node.get("chart-var-name", None):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,5 +10,5 @@ collect_ignore = ["roots"]
 
 
 @pytest.fixture(scope="session")
-def rootdir():
+def rootdir() -> Path:
     return Path(__file__).parent / "roots"

--- a/tests/roots/test-altairplot/errors_warnings.rst
+++ b/tests/roots/test-altairplot/errors_warnings.rst
@@ -1,0 +1,8 @@
+Trigger a NameError
+---------------------------
+...
+
+.. altair-plot::
+
+    polars.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+

--- a/tests/test_altairplot.py
+++ b/tests/test_altairplot.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
@@ -20,11 +20,13 @@ from sphinxext_altair.altairplot import (
 if TYPE_CHECKING:
     from sphinx.application import Sphinx
 
+    from sphinxext_altair.altairplot import BuildEnvironment
+
 
 @pytest.mark.parametrize("add_namespaces_attr", [True, False])
 @pytest.mark.sphinx(testroot="altairplot")
-def test_purge_altair_namespaces(add_namespaces_attr, app):
-    env = app.env
+def test_purge_altair_namespaces(add_namespaces_attr: bool, app: Sphinx) -> None:
+    env: BuildEnvironment = cast("BuildEnvironment", app.env)
     if add_namespaces_attr:
         env._altair_namespaces = {"docname": {}}
 
@@ -48,7 +50,7 @@ def test_purge_altair_namespaces(add_namespaces_attr, app):
         ("editor source", {"editor": True, "source": True, "export": False}),
     ],
 )
-def test_validate_links(links, expected):
+def test_validate_links(links: str, expected: str | bool | dict[str, bool]) -> None:
     if expected == "raise":
         with pytest.raises(
             ValueError, match=r"Following links are invalid: \['unknown'\]"


### PR DESCRIPTION
Resolves https://github.com/vega/sphinxext-altair/issues/12

Had to change the original idea, as a warning `stacklevel` must point to code - but the error code is within an `.rst` node.

# Sample Output
![image](https://github.com/user-attachments/assets/2a2b78fa-252c-459b-bfde-d1d10c2fbc41)
